### PR TITLE
Build php 5.3 using docker

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -115,14 +115,21 @@ build_and_ship_package() {
   curl --user "$BINTRAY_USER":"$BINTRAY_KEY" -X POST https://api.bintray.com/content/"$BINTRAY_USER"/"$BINTRAY_REPO"/5.3-linux/5.3/publish || true
 }
 
+mode="${1:-all}"
 install_dir=/usr/local/php/"$PHP_VERSION"
 tries=10
-sudo mkdir -p "$install_dir" /usr/local/ssl
-sudo chmod -R 777 /usr/local/php /usr/local/ssl
-setup_phpbuild
-build_embed
-build_apache_fpm
-merge_sapi
-configure_php
-build_extensions
-build_and_ship_package
+
+if [[ "$mode" = "all" || "$mode" = "build" ]]; then
+  sudo mkdir -p "$install_dir" /usr/local/ssl
+  sudo chmod -R 777 /usr/local/php /usr/local/ssl
+  setup_phpbuild
+  build_embed
+  build_apache_fpm
+  merge_sapi
+  configure_php
+  build_extensions
+fi
+
+if [[ "$mode" = "all" || "$mode" = "ship" ]]; then
+  build_and_ship_package
+fi

--- a/.github/scripts/build_deps.sh
+++ b/.github/scripts/build_deps.sh
@@ -4,7 +4,7 @@ install_pkg() {
     cd "$pkg_dir" || exit 1
     sudo ./configure --prefix=/usr
     sudo make -j"$(nproc)"
-    sudo make install
+    sudo make install DESTDIR="$DESTDIR"
   )
 }
 
@@ -34,11 +34,12 @@ add_openssl() {
     ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib/openssl-1.0 shared zlib-dynamic
     make depend
     sudo make -j"$(nproc)"
-    sudo make install
+    sudo make install INSTALL_PREFIX="$DESTDIR"
   )
 }
 
 mode="${1:-all}"
+DESTDIR="${2:-}"
 
 if [[ "$mode" = "all" || "$mode" = "autoconf" ]]; then
   add_autoconf

--- a/.github/scripts/build_deps.sh
+++ b/.github/scripts/build_deps.sh
@@ -38,7 +38,17 @@ add_openssl() {
   )
 }
 
-add_autoconf
-add_icu
-add_bison
-add_openssl
+mode="${1:-all}"
+
+if [[ "$mode" = "all" || "$mode" = "autoconf" ]]; then
+  add_autoconf
+fi
+if [[ "$mode" = "all" || "$mode" = "icu" ]]; then
+  add_icu
+fi
+if [[ "$mode" = "all" || "$mode" = "bison" ]]; then
+  add_bison
+fi
+if [[ "$mode" = "all" || "$mode" = "openssl" ]]; then
+  add_openssl
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,10 @@ jobs:
   build53:
     name: Build PHP 5.3
     runs-on: ${{ matrix.operating-system }}
-    container: ubuntu:precise
     strategy:
       fail-fast: false
       matrix:
-        operating-system: [ubuntu-latest]
+        operating-system: [ubuntu-20.04]
         php-version: ['5.3']
     steps:
       - name: Checkout
@@ -35,44 +34,6 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
           BINTRAY_REPO: php
-
-      - name: Check php-cli version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: php -v
-
-      - name: Check php extensions
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: php -m
-
-      - name: Check php-cgi version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: php-cgi -v
-
-      - name: Check php-fpm version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: |
-          php-fpm -v
-          sudo service --status-all 2>&1 | grep "fpm"
-
-      - name: Check apache service
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: |
-          echo "ServerName localhost" | sudo tee -a /etc/apache2/httpd.conf
-          sudo a2enmod php${{ matrix.php-version }} || true
-          sudo /etc/init.d/apache2 restart || true
-          sudo service --status-all 2>&1 | grep "apache"
-
-      - name: Check pecl version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: pecl -V
-
-      - name: Check php-config version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: php-config --version
-
-      - name: Check phpize version
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: phpize -v
 
       - name: Upload Artifact
         if: "contains(github.event.head_commit.message, 'build-php5.3')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,38 +12,17 @@ jobs:
         operating-system: [ubuntu-latest]
         php-version: ['5.3']
     steps:
-      - name: Install required packages
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: |
-          debconf_fix="DEBIAN_FRONTEND=noninteractive"
-          apt-get update
-          apt-get install sudo curl python-software-properties -y
-          LC_ALL=C.UTF-8 sudo apt-add-repository ppa:ondrej/php -y
-          LC_ALL=C.UTF-8 sudo apt-add-repository ppa:ubuntu-toolchain-r/test
-          sudo "$debconf_fix" apt-get update
-          sudo "$debconf_fix" apt-get -y install apache2-mpm-prefork apache2-prefork-dev build-essential checkinstall zlib1g-dev automake autoconf bzip2 git m4 make libstdc++6-4.7-dev gcc-4.7 g++-4.7 gettext expect locales language-pack-de re2c mysql-server postgresql pkg-config libc-client-dev libcurl4-gnutls-dev libacl1-dev libapache2-mod-php5 libapr1-dev libasn1-8-heimdal libattr1-dev libblkid1 libbz2-dev libc6 libcap2 libc-bin libclass-isa-perl libcomerr2 libdb5.1-dev libdbus-1-3 libdebian-installer4 libdrm2 libdrm-intel1 libdrm-nouveau1a libdrm-radeon1 libexpat1-dev libenchant-dev libffi-dev libfreetype6-dev libgcc1 libgcrypt11-dev libgdbm-dev libglib2.0-0 libgnutls-dev libgpg-error0 libgssapi3-heimdal libgssapi-krb5-2 libgmp-dev libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3 libkeyutils1 libklibc libkrb5-26-heimdal libkrb5-dev libkrb5support0 libldb-dev libldap-dev libltdl-dev liblzma-dev libmagic-dev libmount-dev libonig-dev libmysqlclient-dev libncurses5-dev libncursesw5 libnewt-dev libnih-dev libnih-dbus1 libodbc1 libp11-kit0 libpam0g libpam-modules libpam-modules-bin libpciaccess0 libpcre3-dev libplymouth-dev libpng-dev libjpeg-dev libmcrypt-dev libmhash-dev libpspell-dev libpq-dev libreadline-dev librecode-dev libroken18-heimdal libsasl2-dev libselinux1-dev libslang2-dev libsqlite3-dev libssl-dev libswitch-perl libsybdb5 libtasn1-3 libtextwrap-dev libtidy-dev libtinfo-dev libudev-dev libuuid1 libwind0-heimdal libxml2-dev libxpm-dev libxslt-dev libzip-dev
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 4
-          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 4
-          for lib_link in $(find /usr/lib/x86_64-linux-gnu -maxdepth 1 -name "*.so" -printf "%f\n"); do
-            sudo ln -s /usr/lib/x86_64-linux-gnu/$lib_link /usr/lib/$lib_link
-          done
-          sudo ln -sf /usr/lib/libc-client.so.2007e.0 /usr/lib/x86_64-linux-gnu/libc-client.a
-          sudo mkdir -p /usr/c-client/
-          sudo ln -sf /usr/lib/libc-client.so.2007e.0 /usr/c-client/libc-client.a
-          curl -o /tmp/libc.deb -sL http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/libc6_2.19-0ubuntu6_amd64.deb
-          sudo dpkg -i /tmp/libc.deb
-
       - name: Checkout
         if: "contains(github.event.head_commit.message, 'build-php5.3')"
         uses: actions/checkout@v2
 
-      - name: Compile and install packages
-        if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: bash .github/scripts/build_deps.sh
-
       - name: Build
         if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: bash .github/scripts/build.sh build
+        run: |
+          docker build . -f php-5.3/Dockerfile -t php-5.3
+          docker run --name=php-5.3 php-5.3 sh -c exit
+          sudo chmod 777 /usr/local
+          docker cp php-5.3:/usr/local/php /usr/local/php
 
       - name: Ship
         if: "contains(github.event.head_commit.message, 'build-php5.3')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Build
         if: "contains(github.event.head_commit.message, 'build-php5.3')"
+        env:
+          BUILDKIT_STEP_LOG_MAX_SIZE: -1
+          BUILDKIT_STEP_LOG_MAX_SPEED: -1
         run: |
           docker build . -f php-5.3/Dockerfile -t php-5.3
           docker run --name=php-5.3 php-5.3 sh -c exit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         env:
           BUILDKIT_STEP_LOG_MAX_SIZE: -1
           BUILDKIT_STEP_LOG_MAX_SPEED: -1
+          DOCKER_BUILDKIT: 1
         run: |
           docker build . -f php-5.3/Dockerfile -t php-5.3
           docker run --name=php-5.3 php-5.3 sh -c exit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,13 @@ jobs:
         if: "contains(github.event.head_commit.message, 'build-php5.3')"
         run: bash .github/scripts/build_deps.sh
 
-      - name: Build and ship
+      - name: Build
         if: "contains(github.event.head_commit.message, 'build-php5.3')"
-        run: bash .github/scripts/build.sh
+        run: bash .github/scripts/build.sh build
+
+      - name: Ship
+        if: "contains(github.event.head_commit.message, 'build-php5.3')"
+        run: bash .github/scripts/build.sh ship
         env:
           PHP_VERSION: ${{ matrix.php-version }}
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -23,12 +23,24 @@ RUN set -x \
 	&& exit 0
 
 # Build: dependencies
-FROM deps AS build-deps
+FROM deps AS build-deps-prepare
 COPY .github/scripts/build_deps.sh /
-RUN bash -xeu /build_deps.sh autoconf
-RUN bash -xeu /build_deps.sh icu
-RUN bash -xeu /build_deps.sh bison
-RUN bash -xeu /build_deps.sh openssl
+
+FROM build-deps-prepare AS build-autoconf
+RUN bash -xeu /build_deps.sh autoconf /build
+FROM build-deps-prepare AS build-bison
+RUN bash -xeu /build_deps.sh bison /build
+FROM build-deps-prepare AS build-icu
+RUN bash -xeu /build_deps.sh icu /build
+FROM build-deps-prepare AS build-openssl
+RUN bash -xeu /build_deps.sh openssl /build
+
+# Merge layers
+FROM deps AS build-deps
+COPY --from=build-autoconf /build /
+COPY --from=build-bison /build /
+COPY --from=build-icu /build /
+COPY --from=build-openssl /build /
 
 FROM build-deps AS build
 ARG PHP_VERSION=5.3

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -20,8 +20,6 @@ RUN set -x \
 	&& ln -sf /usr/lib/libc-client.so.2007e.0 /usr/lib/x86_64-linux-gnu/libc-client.a \
 	&& mkdir -p /usr/c-client/ \
 	&& ln -sf /usr/lib/libc-client.so.2007e.0 /usr/c-client/libc-client.a \
-	&& curl -o /tmp/libc.deb -sL http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/libc6_2.19-0ubuntu6_amd64.deb \
-	&& dpkg -i /tmp/libc.deb \
 	&& exit 0
 
 # Build

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -1,0 +1,36 @@
+ARG UBUNTU_VERSION=precise
+FROM ubuntu:$UBUNTU_VERSION AS base
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN LC_ALL=C.UTF-8
+
+# Install required packages
+FROM base AS deps
+RUN apt-get update && apt-get install -y sudo curl python-software-properties
+RUN apt-add-repository ppa:ondrej/php -y
+RUN apt-add-repository ppa:ubuntu-toolchain-r/test
+RUN apt-get update && apt-get -y install apache2-mpm-prefork apache2-prefork-dev build-essential checkinstall zlib1g-dev automake autoconf bzip2 git m4 make libstdc++6-4.7-dev gcc-4.7 g++-4.7 gettext expect locales language-pack-de re2c mysql-server postgresql pkg-config libc-client-dev libcurl4-gnutls-dev libacl1-dev libapache2-mod-php5 libapr1-dev libasn1-8-heimdal libattr1-dev libblkid1 libbz2-dev libc6 libcap2 libc-bin libclass-isa-perl libcomerr2 libdb5.1-dev libdbus-1-3 libdebian-installer4 libdrm2 libdrm-intel1 libdrm-nouveau1a libdrm-radeon1 libexpat1-dev libenchant-dev libffi-dev libfreetype6-dev libgcc1 libgcrypt11-dev libgdbm-dev libglib2.0-0 libgnutls-dev libgpg-error0 libgssapi3-heimdal libgssapi-krb5-2 libgmp-dev libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libk5crypto3 libkeyutils1 libklibc libkrb5-26-heimdal libkrb5-dev libkrb5support0 libldb-dev libldap-dev libltdl-dev liblzma-dev libmagic-dev libmount-dev libonig-dev libmysqlclient-dev libncurses5-dev libncursesw5 libnewt-dev libnih-dev libnih-dbus1 libodbc1 libp11-kit0 libpam0g libpam-modules libpam-modules-bin libpciaccess0 libpcre3-dev libplymouth-dev libpng-dev libjpeg-dev libmcrypt-dev libmhash-dev libpspell-dev libpq-dev libreadline-dev librecode-dev libroken18-heimdal libsasl2-dev libselinux1-dev libslang2-dev libsqlite3-dev libssl-dev libswitch-perl libsybdb5 libtasn1-3 libtextwrap-dev libtidy-dev libtinfo-dev libudev-dev libuuid1 libwind0-heimdal libxml2-dev libxpm-dev libxslt-dev libzip-dev
+RUN set -x \
+	&& update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.7 4 \
+	&& update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-4.7 4 \
+	&& \
+		for lib_link in $(find /usr/lib/x86_64-linux-gnu -maxdepth 1 -name "*.so" -printf "%f\n"); do \
+			ln -s /usr/lib/x86_64-linux-gnu/$lib_link /usr/lib/$lib_lin; \
+		done \
+	&& ln -sf /usr/lib/libc-client.so.2007e.0 /usr/lib/x86_64-linux-gnu/libc-client.a \
+	&& mkdir -p /usr/c-client/ \
+	&& ln -sf /usr/lib/libc-client.so.2007e.0 /usr/c-client/libc-client.a \
+	&& curl -o /tmp/libc.deb -sL http://archive.ubuntu.com/ubuntu/pool/main/e/eglibc/libc6_2.19-0ubuntu6_amd64.deb \
+	&& dpkg -i /tmp/libc.deb \
+	&& exit 0
+
+# Build
+FROM deps AS build-deps
+COPY .github/scripts/build_deps.sh /
+RUN bash -xeu /build_deps.sh
+
+FROM build-deps AS build
+ARG PHP_VERSION=5.3
+ENV PHP_VERSION $PHP_VERSION
+COPY .github/scripts/ /.github/scripts/
+RUN bash -xeu /.github/scripts/build.sh build

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -22,10 +22,13 @@ RUN set -x \
 	&& ln -sf /usr/lib/libc-client.so.2007e.0 /usr/c-client/libc-client.a \
 	&& exit 0
 
-# Build
+# Build: dependencies
 FROM deps AS build-deps
 COPY .github/scripts/build_deps.sh /
-RUN bash -xeu /build_deps.sh
+RUN bash -xeu /build_deps.sh autoconf
+RUN bash -xeu /build_deps.sh icu
+RUN bash -xeu /build_deps.sh bison
+RUN bash -xeu /build_deps.sh openssl
 
 FROM build-deps AS build
 ARG PHP_VERSION=5.3


### PR DESCRIPTION
Implements the idea of moving build process to docker image:
- https://github.com/shivammathur/setup-php/issues/358#issuecomment-740580068

this way can develop this locally without needing an appropriate VM. and not even Linux (macOS).

The build can be performed locally with:

```
docker build . -f php-5.3/Dockerfile -t php-5.3
```

refs:
- https://github.com/shivammathur/setup-php/issues/386#issuecomment-752745829
- https://github.com/shivammathur/php5-ubuntu/commit/a9a18a5deb34504464110878d1ab0ea10e22d439
