### PR TITLE
Setup php-build in separate docker layer

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -113,14 +113,26 @@ if [[ "$mode" = "all" || "$mode" = "php-build" ]]; then
   clone_phpbuild
 fi
 
-if [[ "$mode" = "all" || "$mode" = "build" ]]; then
+if [[ "$mode" = "all" || "$mode" = "setup-phpbuild" ]]; then
   sudo mkdir -p "$install_dir" /usr/local/ssl
   sudo chmod -R 777 /usr/local/php /usr/local/ssl
   setup_phpbuild
+fi
+
+if [[ "$mode" = "all" || "$mode" = "build-embed" ]]; then
   build_embed
+fi
+
+if [[ "$mode" = "all" || "$mode" = "build-fpm" ]]; then
   build_apache_fpm
+fi
+
+if [[ "$mode" = "all" || "$mode" = "merge_sapi" ]]; then
   merge_sapi
   configure_php
+fi
+
+if [[ "$mode" = "all" || "$mode" = "build-extensions" ]]; then
   build_extensions
 fi
 

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -1,10 +1,11 @@
+clone_phpbuild() {
+  [ ! -d ~/php-build ] || return 0
+
+  git clone git://github.com/php-build/php-build ~/php-build || exit
+  (cd ~/php-build && sudo ./install.sh) || exit
+}
+
 setup_phpbuild() {
-  (
-    cd ~ || exit
-    git clone git://github.com/php-build/php-build
-    cd php-build || exit
-    sudo ./install.sh
-  )
   sudo cp .github/scripts/"$PHP_VERSION" /usr/local/share/php-build/definitions/
   if [ "$PHP_VERSION" = "5.3" ]; then
     sudo cp .github/scripts/php-5.3.29-multi-sapi.patch /usr/local/share/php-build/patches/
@@ -107,6 +108,10 @@ build_and_ship_package() {
 mode="${1:-all}"
 install_dir=/usr/local/php/"$PHP_VERSION"
 tries=10
+
+if [[ "$mode" = "all" || "$mode" = "php-build" ]]; then
+  clone_phpbuild
+fi
 
 if [[ "$mode" = "all" || "$mode" = "build" ]]; then
   sudo mkdir -p "$install_dir" /usr/local/ssl

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -75,6 +75,7 @@ build_php() {
 }
 
 merge_sapi() {
+  rm -rf "$install_dir"
   mv "$install_dir-fpm" "$install_dir"
   cp "$install_dir-embed/lib/libphp5.so" "$install_dir/usr/lib/libphp$PHP_VERSION.so"
   sudo sed -i 's/php_sapis=" apache2handler cli fpm cgi"/php_sapis=" apache2handler cli fpm cgi embed"/' "$install_dir"/bin/php-config

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -54,13 +54,24 @@ RUN wget https://secure.php.net/distributions/php-5.3.29.tar.bz2
 
 FROM fetch-php-$PHP_VERSION AS fetch-php
 
-FROM build-deps AS build
+FROM build-deps AS build-prepare
 ARG PHP_VERSION
 ENV PHP_VERSION $PHP_VERSION
 COPY --from=fetch-php /tmp/php-build/packages/php-*.tar.bz2 /tmp/php-build/packages/
 
 COPY .github/scripts/build.sh /.github/scripts/build.sh
 RUN bash -xeu /.github/scripts/build.sh php-build
-
 COPY .github/scripts/ /.github/scripts/
-RUN bash -xeu /.github/scripts/build.sh build
+RUN bash -xeu /.github/scripts/build.sh setup-phpbuild
+
+FROM build-prepare AS build-embed
+RUN bash -xeu /.github/scripts/build.sh build-embed
+FROM build-prepare AS build-fpm
+RUN bash -xeu /.github/scripts/build.sh build-fpm
+
+FROM build-prepare AS php-build
+ARG PHP_VERSION
+COPY --from=build-embed /usr/local/php/$PHP_VERSION-embed /usr/local/php/$PHP_VERSION-embed
+COPY --from=build-fpm /usr/local/php/$PHP_VERSION-fpm /usr/local/php/$PHP_VERSION-fpm
+RUN bash -xeu /.github/scripts/build.sh merge_sapi
+RUN bash -xeu /.github/scripts/build.sh build-extensions

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -45,5 +45,9 @@ COPY --from=build-openssl /build /
 FROM build-deps AS build
 ARG PHP_VERSION=5.3
 ENV PHP_VERSION $PHP_VERSION
+
+COPY .github/scripts/build.sh /.github/scripts/build.sh
+RUN bash -xeu /.github/scripts/build.sh php-build
+
 COPY .github/scripts/ /.github/scripts/
 RUN bash -xeu /.github/scripts/build.sh build

--- a/php-5.3/Dockerfile
+++ b/php-5.3/Dockerfile
@@ -1,8 +1,13 @@
 ARG UBUNTU_VERSION=precise
+ARG PHP_VERSION=5.3
 FROM ubuntu:$UBUNTU_VERSION AS base
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN LC_ALL=C.UTF-8
+
+# Stage that can be used to fetch foreign files
+FROM base AS fetch
+RUN apt-get update && apt-get install -y wget ca-certificates
 
 # Install required packages
 FROM base AS deps
@@ -42,9 +47,17 @@ COPY --from=build-bison /build /
 COPY --from=build-icu /build /
 COPY --from=build-openssl /build /
 
+# Fetch php source
+FROM fetch AS fetch-php-5.3
+WORKDIR /tmp/php-build/packages
+RUN wget https://secure.php.net/distributions/php-5.3.29.tar.bz2
+
+FROM fetch-php-$PHP_VERSION AS fetch-php
+
 FROM build-deps AS build
-ARG PHP_VERSION=5.3
+ARG PHP_VERSION
 ENV PHP_VERSION $PHP_VERSION
+COPY --from=fetch-php /tmp/php-build/packages/php-*.tar.bz2 /tmp/php-build/packages/
 
 COPY .github/scripts/build.sh /.github/scripts/build.sh
 RUN bash -xeu /.github/scripts/build.sh php-build


### PR DESCRIPTION
This adds separate layers for some steps allowing to cache and build in parallel.

This is a prelude of an idea to build other 5.x from source:
- https://github.com/shivammathur/php5-ubuntu/pull/1#issuecomment-753980535

fpm and embed are built parallel:

![image](https://user-images.githubusercontent.com/199095/106568936-9fe59b00-653c-11eb-808e-4a46c245bef4.png)
